### PR TITLE
Remove duplicate case datum

### DIFF
--- a/srfi/180/body.scm
+++ b/srfi/180/body.scm
@@ -538,7 +538,6 @@
       ((#\tab) (accumulator "\\t"))
       ((#\backspace) (accumulator "\\b"))
       ((#\x0c) (accumulator "\\f"))
-      ((#\x0d) (accumulator "\\r"))
       (else (accumulator char))))
 
   (define (write-json-string string accumulator)


### PR DESCRIPTION
According to R7RS, it's an error if a case <datum> is duplicated. #\return and #\x0d are the same character, so this commit removes the latter to keep consistency.

Note: I noticed this while compiling the code with Gambit, which errors out due to this problem.